### PR TITLE
Fixing typos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Some people still insist on using MD5 to reference file samples, for various rea
 
 ## How does it work?
 
-For every bit we want to encode, a colliding MD5 block has been pre-calculated using FastColl. As summarised [here](https://github.com/corkami/collisions/tree/master/hashquines#read-an-encoded-value), each collision gives us a pair of blocks that we can swap out without changing the overall MD5 hash. The loader checks which block was chosen at runtime, to decode the bit.
+For every bit we want to encode, a colliding MD5 block has been pre-calculated using [FastColl](https://github.com/cr-marcstevens/hashclash/tree/master/src/md5fastcoll). As summarised [here](https://github.com/corkami/collisions/tree/master/hashquines#read-an-encoded-value), each collision gives us a pair of blocks that we can swap out without changing the overall MD5 hash. The loader checks which block was chosen at runtime, to decode the bit.
 
 To encode 4KB of data, we need to generate 4\*1024\*8 collisions (which takes a few hours), taking up 4MB of space in the final file.
 

--- a/sample_payloads/linux_syscall_support.h
+++ b/sample_payloads/linux_syscall_support.h
@@ -46,7 +46,7 @@
  *   the necessary definitions.
  *
  * SYS_ERRNO:
- *   All system calls will update "errno" unless overriden by setting the
+ *   All system calls will update "errno" unless overridden by setting the
  *   SYS_ERRNO macro prior to including this file. SYS_ERRNO should be
  *   an l-value.
  *
@@ -1823,7 +1823,7 @@ struct kernel_statx {
 #ifndef __NR_getcpu
 #define __NR_getcpu             302
 #endif
-/* End of powerpc defininitions                                              */
+/* End of powerpc definitions                                              */
 #elif defined(__s390__)
 #ifndef __NR_quotactl
 #define __NR_quotactl           131


### PR DESCRIPTION
This is a follow up of #2. Changes have been merged upstream meanwhile, this PR pulls them down now.
This PR also add a link to the `fastcoll` repo to `README.md`.